### PR TITLE
Change Font to Monotype Font Family in Panel

### DIFF
--- a/src/ui/window.py
+++ b/src/ui/window.py
@@ -534,6 +534,15 @@ class MUDPanel(AccessPanel):
         self.output.SetFocus()
         self.nb_unread = 0
 
+        # font setup
+        size = 12
+        # modern is a monotype font
+        family = wx.FONTFAMILY_MODERN
+
+        font = wx.Font(size, family, wx.NORMAL, wx.NORMAL)
+        # only sets the output window font
+        self.output.SetFont(font)
+
         # Event binding
         self.output.Bind(wx.EVT_TEXT_PASTE, self.OnPaste)
 


### PR DESCRIPTION
# Summary of Changes
This changes the font in the panel to the Modern family of wxPython - this is a Monospace/fixed pitch font family.
This should help ensure ASCII art appears correctly aligned - and shouldn't affect any users of cocomud negatively.